### PR TITLE
FIX: Refresh Submission API and fix path problem in Windows

### DIFF
--- a/contest/views.py
+++ b/contest/views.py
@@ -24,7 +24,7 @@ class ContestView(APIView, PaginationHandlerMixin):
     permission_classes = [IsSafeMethod | IsClassProfOrTA]
     pagination_class = BasicPagination
 
-    # 05-07
+    # 05-08
     # 비공개 관련 처리 필요함
     def get(self, request: Request, class_id: int) -> Response:
         contest_lists = Contest.objects.filter(class_id=class_id).order_by("start_time").active()
@@ -37,7 +37,7 @@ class ContestView(APIView, PaginationHandlerMixin):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    # 05-08
+    # 05-09
     def post(self, request: Request, class_id: int) -> Response:
         class_ = get_class(class_id)
 
@@ -58,7 +58,7 @@ class ContestView(APIView, PaginationHandlerMixin):
 class ContestCheckView(APIView):
     permission_classes = [IsClassProfOrTA]
 
-    # 05-09
+    # 05-10
     def patch(self, request: Request, class_id: int, contest_id: int) -> Response:
         # 0315 permission
         contest = get_contest(contest_id)

--- a/submission/urls.py
+++ b/submission/urls.py
@@ -1,14 +1,15 @@
 from django.urls import path
 
 from submission.views import (
-    SubmissionClassListView, SubmissionClassCsvDownloadView, SubmissionClassIpynbDownloadView, SubmissionCompetitionCsvDownloadView, SubmissionCompetitionIpynbDownloadView
+    SubmissionClassListView, SubmissionClassCsvDownloadView, SubmissionClassIpynbDownloadView,
+    SubmissionCompetitionCsvDownloadView, SubmissionCompetitionIpynbDownloadView
 )
 
 app_name = "submission"
 urlpatterns = [
     path('', SubmissionClassListView.as_view(), name="class_submission_list"),
-    path('class/<int:submission_id>/download/csv/',SubmissionClassCsvDownloadView.as_view()),
-    path('class/<int:submission_id>/download/ipynb/',SubmissionClassIpynbDownloadView.as_view()),
-    path('competition/<int:submission_id>/download/csv/',SubmissionCompetitionCsvDownloadView.as_view()),
-    path('competition/<int:submission_id>/download/ipynb/',SubmissionCompetitionIpynbDownloadView.as_view()),
+    path('class/<int:submission_id>/download/csv/', SubmissionClassCsvDownloadView.as_view()),
+    path('class/<int:submission_id>/download/ipynb/', SubmissionClassIpynbDownloadView.as_view()),
+    path('competition/<int:submission_id>/download/csv/', SubmissionCompetitionCsvDownloadView.as_view()),
+    path('competition/<int:submission_id>/download/ipynb/', SubmissionCompetitionIpynbDownloadView.as_view()),
 ]

--- a/submission/views.py
+++ b/submission/views.py
@@ -251,13 +251,14 @@ class SubmissionCompetitionListView(APIView, PaginationHandlerMixin):
         competition = get_competition(competition_id)
         username = request.GET.get('username', '')
 
-        submission_comptition_list = SubmissionCompetition.objects.filter(competition_id=competition_id).order_by('-created_time')
+        submission_competition_list = SubmissionCompetition.objects.filter(competition_id=competition_id).order_by(
+            '-created_time')
         if username:
-            submission_comptition_list = submission_comptition_list.filter(username=username)
+            submission_competition_list = submission_competition_list.filter(username=username)
 
         obj_list = []
 
-        for submission in submission_comptition_list:
+        for submission in submission_competition_list:
             # csv_url = "http://{0}/api/submissions/competition/{1}/download/csv".format(IP_ADDR, submission.id)
             # ipynb_url = "http://{0}/api/submissions/competition/{1}/download/ipynb".format(IP_ADDR, submission.id)
 

--- a/submission/views.py
+++ b/submission/views.py
@@ -31,7 +31,7 @@ class SubmissionClassView(APIView, EvaluationMixin):
     permission_classes = [IsClassUser]
 
     # 05-16
-    def post(self, request, class_id, contest_id, cp_id):
+    def post(self, request: Request, class_id: int, contest_id: int, cp_id: int) -> Response:
         class_ = get_class(class_id)
         contest = get_contest(contest_id)
         contest_problem = get_contest_problem(cp_id)
@@ -109,7 +109,7 @@ class SubmissionClassListView(APIView, PaginationHandlerMixin):
     pagination_class = BasicPagination
 
     # 07-00 유저 submission 내역 조회
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         cp_id = request.GET.get('cpid', 0)
         contest_problem = get_contest_problem(cp_id)
         submission_class_list = SubmissionClass.objects.all().filter(username=request.user).filter(
@@ -145,7 +145,7 @@ class SubmissionClassCheckView(APIView):
     # 05-17
     permission_classes = [IsClassUser]
 
-    def patch(self, request, class_id, contest_id, cp_id):
+    def patch(self, request: Request, class_id: int, contest_id: int, cp_id: int) -> Response:
         class_ = get_class(class_id)
         contest = get_contest(contest_id)
         contest_problem = get_contest_problem(cp_id)
@@ -182,7 +182,7 @@ class SubmissionCompetitionView(APIView, EvaluationMixin):
     permission_classes = [IsCompetitionUser]
 
     # 06-04 대회 유저 파일 제출
-    def post(self, request, competition_id):
+    def post(self, request: Request, competition_id: int) -> Response:
         competition = get_competition(competition_id)
         # permission check - 대회에 참가한 학생만 제출 가능
 
@@ -247,7 +247,7 @@ class SubmissionCompetitionListView(APIView, PaginationHandlerMixin):
     pagination_class = BasicPagination
 
     # 06-07 유저 submission 내역 조회
-    def get(self, request, competition_id):
+    def get(self, request: Request, competition_id: int) -> Response:
         competition = get_competition(competition_id)
         username = request.GET.get('username', '')
 
@@ -286,7 +286,7 @@ class SubmissionCompetitionCheckView(APIView):
     permission_classes = [IsCompetitionUser]
 
     # 06-06 submission 리더보드 체크
-    def patch(self, request, competition_id):
+    def patch(self, request: Request, competition_id: int) -> Response:
         competition = get_competition(competition_id)
 
         data = request.data
@@ -320,7 +320,7 @@ class SubmissionCompetitionCheckView(APIView):
 class SubmissionClassCsvDownloadView(APIView):
     permission_classes = [IsSubClassDownloadableUser]
 
-    def get(self, request, submission_id):
+    def get(self, request: Request, submission_id: int) -> HttpResponse:
         submission = get_submission_class(submission_id)
 
         os_info = platform.system()
@@ -345,7 +345,8 @@ class SubmissionClassCsvDownloadView(APIView):
 class SubmissionClassIpynbDownloadView(APIView):
     permission_classes = [IsSubClassDownloadableUser]
 
-    def get(self, request, submission_id):
+    # 
+    def get(self, request: Request, submission_id: int) -> HttpResponse:
         submission = get_submission_class(submission_id)
 
         os_info = platform.system()
@@ -370,7 +371,7 @@ class SubmissionClassIpynbDownloadView(APIView):
 class SubmissionCompetitionCsvDownloadView(APIView):
     permission_classes = [IsSubCompDownloadableUser]
 
-    def get(self, request, submission_id):
+    def get(self, request: Request, submission_id: int) -> HttpResponse:
         submission = get_submission_competition(submission_id)
 
         # It should be considered what operating system is running
@@ -397,7 +398,7 @@ class SubmissionCompetitionCsvDownloadView(APIView):
 class SubmissionCompetitionIpynbDownloadView(APIView):
     permission_classes = [IsSubCompDownloadableUser]
 
-    def get(self, request, submission_id):
+    def get(self, request: Request, submission_id: int) -> HttpResponse:
         submission = get_submission_competition(submission_id)
 
         os_info = platform.system()

--- a/submission/views.py
+++ b/submission/views.py
@@ -48,7 +48,7 @@ class SubmissionClassView(APIView, EvaluationMixin):
         if contest.is_exam and is_class_student:
             # ip 중복 체크
             exam = Exam.objects.get(user=request.user, contest=contest)
-            if exam.is_duplicated: # 중복이면 에러
+            if exam.is_duplicated:  # 중복이면 에러
                 return Response(msg_SubmissionClassView_post_e_3, status=status.HTTP_400_BAD_REQUEST)
 
         data = request.data.copy()
@@ -318,15 +318,13 @@ class SubmissionClassCsvDownloadView(APIView):
     def get(self, request, submission_id):
         submission = get_submission_class(submission_id)
 
+        os_info = platform.system()
+
         # Define Django project base directory
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        # result = /Users/ingyu/Desktop/BE/problem
-        BASE_DIR = BASE_DIR.replace("/submission", "")
 
-        csv_path = str(submission.csv.path).split('uploads/', 1)[1]
-        filename = csv_path.split('/', 2)[2]
-        filename = urllib.parse.quote(filename.encode('utf-8'))
-        filepath = BASE_DIR + '/uploads/' + csv_path
+        (filename, filepath) = download.csv_download_windows(submission.csv.path, BASE_DIR) \
+            if os_info == 'Windows' else download.csv_download_nix(submission.csv.path, BASE_DIR)
 
         # Open the file for reading content
         path = open(filepath, 'r')
@@ -345,15 +343,13 @@ class SubmissionClassIpynbDownloadView(APIView):
     def get(self, request, submission_id):
         submission = get_submission_class(submission_id)
 
+        os_info = platform.system()
+
         # Define Django project base directory
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        # result = /Users/ingyu/Desktop/BE/problem
-        BASE_DIR = BASE_DIR.replace("/submission", "")
 
-        csv_path = str(submission.ipynb.path).split('uploads/', 1)[1]
-        filename = csv_path.split('/', 2)[2]
-        filename = urllib.parse.quote(filename.encode('utf-8'))
-        filepath = BASE_DIR + '/uploads/' + csv_path
+        (filename, filepath) = download.ipynb_download_windows(submission.ipynb.path, BASE_DIR) \
+            if os_info == 'Windows' else download.ipynb_download_nix(submission.ipynb.path, BASE_DIR)
 
         # Open the file for reading content
         path = open(filepath, 'r')
@@ -372,15 +368,15 @@ class SubmissionCompetitionCsvDownloadView(APIView):
     def get(self, request, submission_id):
         submission = get_submission_competition(submission_id)
 
+        # It should be considered what operating system is running
+
+        os_info = platform.system()
+
         # Define Django project base directory
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        # result = /Users/ingyu/Desktop/BE/problem
-        BASE_DIR = BASE_DIR.replace("/submission", "")
 
-        csv_path = str(submission.csv.path).split('uploads/', 1)[1]
-        filename = csv_path.split('/', 2)[2]
-        filename = urllib.parse.quote(filename.encode('utf-8'))
-        filepath = BASE_DIR + '/uploads/' + csv_path
+        (filename, filepath) = download.csv_download_windows(submission.csv.path, BASE_DIR) \
+            if os_info == 'Windows' else download.csv_download_nix(submission.csv.path, BASE_DIR)
 
         # Open the file for reading content
         path = open(filepath, 'r')
@@ -399,15 +395,13 @@ class SubmissionCompetitionIpynbDownloadView(APIView):
     def get(self, request, submission_id):
         submission = get_submission_competition(submission_id)
 
+        os_info = platform.system()
+
         # Define Django project base directory
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        # result = /Users/ingyu/Desktop/BE/problem
-        BASE_DIR = BASE_DIR.replace("/submission", "")
 
-        csv_path = str(submission.ipynb.path).split('uploads/', 1)[1]
-        filename = csv_path.split('/', 2)[2]
-        filename = urllib.parse.quote(filename.encode('utf-8'))
-        filepath = BASE_DIR + '/uploads/' + csv_path
+        (filename, filepath) = download.ipynb_download_windows(submission.ipynb.path, BASE_DIR) \
+            if os_info == 'Windows' else download.ipynb_download_nix(submission.ipynb.path, BASE_DIR)
 
         # Open the file for reading content
         path = open(filepath, 'r')

--- a/submission/views.py
+++ b/submission/views.py
@@ -51,13 +51,18 @@ class SubmissionClassView(APIView, EvaluationMixin):
             if exam.is_duplicated:  # 중복이면 에러
                 return Response(msg_SubmissionClassView_post_e_3, status=status.HTTP_400_BAD_REQUEST)
 
-        data = request.data.copy()
-        csv_str = data.get('csv', '')
-        if csv_str != '':
-            csv_str = csv_str.name.split('.')[-1]
-        ipynb_str = data.get('ipynb', '')
-        if ipynb_str != '':
-            ipynb_str = ipynb_str.name.split('.')[-1]
+        data = request.data
+
+        csv_file = data.get('csv')
+        if csv_file is None:
+            return Response(msg_SubmissionClassView_post_e_1, status=status.HTTP_400_BAD_REQUEST)
+        csv_str = csv_file.name.split('.')[-1]
+
+        ipynb_file = data.get('ipynb')
+        if ipynb_file is None:
+            return Response(msg_SubmissionClassView_post_e_2, status=status.HTTP_400_BAD_REQUEST)
+        ipynb_str = ipynb_file.name.split('.')[-1]
+
         if csv_str != 'csv':
             return Response(msg_SubmissionClassView_post_e_1, status=status.HTTP_400_BAD_REQUEST)
         if ipynb_str != 'ipynb':
@@ -187,8 +192,8 @@ class SubmissionCompetitionView(APIView, EvaluationMixin):
 
         user = get_username(request.user.username)
         if CompetitionUser.objects.filter(username=request.user.username).filter(
-                competition_id=competition_id).count() == 0:
-            return Response({'error': "대회에 참가하지 않았습니다."}, status=status.HTTP_400_BAD_REQUEST)
+                                          competition_id=competition_id).count() == 0:
+            return Response(msg_SubmissionCompetitionView_post_e_1, status=status.HTTP_400_BAD_REQUEST)
 
         data = request.data.copy()
 

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,18 +1,57 @@
+import datetime
+import platform
 import uuid
+import re
+from pathlib import Path
 
 IP_ADDR = "15.165.30.200:8000"
 
+
 def upload_to_data(instance, filename):
-    instance_slug = getattr(instance,"slug",False)
+    instance_slug = getattr(instance, "slug", False)
     if not instance_slug:
-        instance_slug = str(uuid.uuid4()).replace("-","")
-    return "uploads/{0}/{1}/{2}" . format (instance._meta.app_label, instance_slug, filename)
+        instance_slug = str(uuid.uuid4()).replace("-", "")
+    return "uploads/{0}/{1}/{2}".format(instance._meta.app_label, instance_slug, filename)
+
 
 def upload_to_solution(instance, filename):
-    instance_slug = getattr(instance,"slug",False)
+    instance_slug = getattr(instance, "slug", False)
     if not instance_slug:
-        instance_slug = str(uuid.uuid4()).replace("-","")
-    return "uploads/solution/{0}/{1}" . format (instance_slug, filename)
+        instance_slug = str(uuid.uuid4()).replace("-", "")
+    return "uploads/solution/{0}/{1}".format(instance_slug, filename)
+
 
 def upload_to_submission(instance, filename):
-    return "uploads/submission/{0}/{1}" . format (instance.path.path, filename)
+    return "uploads/submission/{0}/{1}".format(instance.path.path, filename)
+
+
+# OS에 맞춰 파일 이름을 추출해 반환
+def get_filename(filepath: str) -> str:
+    if platform.system() == 'Windows':
+        filename = filepath.split('\\')[-1]
+    else:
+        filename = filepath.split('/')[-1]
+
+    return filename
+
+
+# Convert datetime format with user requested separator and regular expression
+def convert_date_format(date: datetime.datetime, separator: str = '-', rexp: str = None) -> str:
+    rexp = rexp if rexp is not None else '[ :\-.]'
+    elems = re.split(rexp, str(date))
+
+    return separator.join(elems)
+
+
+# 여러 층에 걸쳐 디렉토리를 만듦
+def make_mult_level_dir(current_path: Path, target: str) -> None:
+    dirs = target.split('/')
+    for d in dirs:
+        current_path /= d
+        if current_path.is_dir() is False:
+            current_path.mkdir()
+
+
+# 현재 시간보다 이전에 끝난 경우 False를 반환
+def is_temp(date: datetime.datetime) -> bool:
+    return False if datetime.datetime.now() > date else True

--- a/utils/download.py
+++ b/utils/download.py
@@ -1,0 +1,74 @@
+import io
+import mimetypes
+import urllib
+from pathlib import Path, PureWindowsPath, PurePosixPath
+from typing import Any
+
+from django.http import HttpResponse
+
+from competition.models import Competition
+
+# TODO : Convert these file to respond the convenient pathlib library
+
+
+# For Windows
+def csv_download_windows(submission_path: str, base_dir: str or bytes) -> (str, str):
+    base_dir = base_dir.replace("\\submission", "")
+    csv_path = str(submission_path).split('uploads\\', 1)[1]
+    filename = csv_path.split('\\', 2)[2]
+    filename = urllib.parse.quote(filename.encode('utf-8'))
+    filepath = base_dir + '\\uploads\\' + csv_path
+
+    return filename, filepath
+
+
+# For Unix or Unix-compatible operating systems
+def csv_download_nix(submission_path: str, base_dir: str or bytes) -> (str, str):
+    base_dir = base_dir.replace("/submission", "")
+
+    csv_path = str(submission_path).split('uploads/', 1)[1]
+    filename = csv_path.split('/', 2)[2]
+    filename = urllib.parse.quote(filename.encode('utf-8'))
+    filepath = base_dir + '/uploads/' + csv_path
+
+    return filename, filepath
+
+
+def ipynb_download_windows(submission_path: str, base_dir: str or bytes) -> (str, str):
+    base_dir = base_dir.replace("\\submission", "")
+
+    ipynb_path = str(submission_path).split('uploads\\', 1)[1]
+    filename = ipynb_path.split('\\', 2)[2]
+    filename = urllib.parse.quote(filename.encode('utf-8'))
+    filepath = base_dir + '\\uploads\\' + ipynb_path
+
+    return filename, filepath
+
+
+def ipynb_download_nix(submission_path: str, base_dir: str or bytes) -> (str, str):
+    base_dir = base_dir.replace("/submission", "")
+
+    ipynb_path = str(submission_path).split('uploads/', 1)[1]
+    filename = ipynb_path.split('/', 2)[2]
+    filename = urllib.parse.quote(filename.encode('utf-8'))
+    filepath = base_dir + '/uploads/' + ipynb_path
+
+    return filename, filepath
+
+
+# Get mime type
+def get_mimetype(filepath: Path) -> str:
+    # Set the mime type
+    mime_type, _ = mimetypes.guess_type(filepath)
+
+    return mime_type
+
+
+# Attach HTTP header
+def get_attachment_response(filepath: Path, mime_type: str) -> HttpResponse:
+    # Open the file for reading content
+    path = open(filepath, 'rb')
+    response = HttpResponse(path, content_type=mime_type)
+    response['Content-Disposition'] = 'attachment; filename*=UTF-8\'\'%s' % str(filepath.name)
+
+    return response

--- a/utils/message.py
+++ b/utils/message.py
@@ -3,13 +3,13 @@
 # ex) msg_ListUsers_get_e = {"error":"처리에 실패했습니다"}
 
 msg_success = {"success":"성공했습니다"}
-msg_error = {"error":"실패"}
+msg_error = {"error": "실패"}
 msg_error_id = {"error": "올바르지 않은 URL 입니다."}
 msg_error_diff_user = {"error": "작성자만 수정/삭제 가능합니다."}
 msg_time_error = {'error': '제한된 시간입니다.'}
-msg_user_model_username_unique = {'unique' : '중복된 ID 입니다.'}
-msg_user_model_email_unique = {'unique' : '중복된 email 입니다.'}
-msg_problem_model_title_unique = {'unique' : '중복된 제목 입니다.'}
+msg_user_model_username_unique = {'unique': '중복된 ID 입니다.'}
+msg_user_model_email_unique = {'unique': '중복된 email 입니다.'}
+msg_problem_model_title_unique = {'unique': '중복된 제목 입니다.'}
 
 # account
 
@@ -33,9 +33,10 @@ msg_ExamParticipateView_get_e_2 = {"error": "해당 class에 속하지 않습니
 
 # problem
 msg_ProblemDetailView_delete_e_1 = {"success": "문제가 제거되었습니다."}
-msg_ProblemView_post_e_1 =  {"error": "파일을 업로드 해주세요."}
+msg_ProblemView_post_e_1 = {"error": "파일을 업로드 해주세요."}
 msg_ProblemView_post_e_2 = {"error": "올바른 데이터 파일을 업로드 해주세요."}
 msg_ProblemView_post_e_3 = {"error": "올바른 정답 파일을 업로드 해주세요."}
+
 
 # proposal
 
@@ -46,6 +47,6 @@ msg_SubmissionCheckView_patch_e_1 = {"error": "username"}
 msg_SubmissionClassView_post_e_1 = {"error": "올바른 csv 파일을 업로드 해주세요."}
 msg_SubmissionClassView_post_e_2 = {"error": "올바른 ipynb 파일을 업로드 해주세요."}
 msg_SubmissionClassView_post_e_3 = {"error": "ip가 중복입니다"}
-
+msg_SubmissionCompetitionView_post_e_1 = {'error': "대회에 참가하지 않았습니다."}
 # uploads
 


### PR DESCRIPTION
### 공통 수정사항
* API 명세서 index 주석 처리
* dictionary 접근 시 get 함수 이용

### 추가된 점
없음

### 수정된 점
* 관할 application 쪽에 Python typing 적용
* **여러 개의 object를 반환하는 클래스에 Pagination을 적용해 FE 요구 사항 준수** (여기서는 대상이 없었음)
* Path에서 Windows와 UNIX 간 차이로 한쪽에서 오류가 발생하는 문제 해결
* 일부 오류 부분 수정

### 문제점
* 임시로 4개의 메소드로 path 문제에 대응했으나 pathlib를 사용하면 더 쉽게 해결할 수 있음. 차후 리팩토링 예정
* 다운로드 클래스에 번호가 할당되어 있지 않은데, 차후에 부여할 예정
