### PR TITLE
Response Error Message 형식 추가 - Problem, Proposal, Leaderboard

### DIFF
--- a/problem/views/admin.py
+++ b/problem/views/admin.py
@@ -18,7 +18,7 @@ class BasicPagination(PageNumberPagination):
     page_size_query_param = 'limit'
 
 
-class AdminProblemView(APIView,PaginationHandlerMixin):
+class AdminProblemView(APIView, PaginationHandlerMixin):
     permission_classes = [IsAdmin]
     pagination_class = BasicPagination
 

--- a/problem/views/general.py
+++ b/problem/views/general.py
@@ -11,8 +11,7 @@ from rest_framework import status
 from utils.get_obj import *
 from utils.message import *
 
-from django.core.exceptions import ObjectDoesNotExist
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import ParseError, NotFound
 from utils.common import IP_ADDR
 import os
 import shutil
@@ -35,7 +34,7 @@ class ProblemView(APIView, PaginationHandlerMixin):
     permission_classes = [(IsAuthenticated & (IsProf | IsTA)) | IsAdmin]
     pagination_class = BasicPagination
 
-    # 03-01
+    # 03-01 problem 전체 조회
     def get(self, request):
         if request.user.privilege == 0:
             problems = Problem.objects.filter(Q(created_user=request.user)).active()
@@ -70,7 +69,7 @@ class ProblemView(APIView, PaginationHandlerMixin):
             serializer = AllProblemSerializer(page, many=True)
         return Response(serializer.data)
 
-    # 03-02
+    # 03-02 problem 생성
     def post(self, request):
         data = request.data.copy()
 
@@ -97,13 +96,13 @@ class ProblemView(APIView, PaginationHandlerMixin):
             problem.save()
             return Response(problem.data, status=status.HTTP_200_OK)
         else:
-            return Response(problem.errors, status=status.HTTP_400_BAD_REQUEST)
+            raise ParseError(detail='ParseError')
 
 
 class ProblemDetailView(APIView):
     permission_classes = [IsProblemOwnerOrReadOnly|IsAdmin]
 
-    # 03-04
+    # 03-04 problem 세부 조회
     def get(self, request, problem_id):
         problem = get_problem(problem_id)
 

--- a/problem/views/general.py
+++ b/problem/views/general.py
@@ -185,22 +185,21 @@ class ProblemDataDownloadView(APIView):
     def get(self, request, problem_id):
         problem = get_problem(problem_id)
 
+        os_info = platform.system()
+
         # Define Django project base directory
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        # result = /Users/ingyu/Desktop/BE/problem
-        BASE_DIR = BASE_DIR.replace("/problem", "")
-
-        data_path = str(problem.data.path).split('uploads/', 1)[1]
-        filename = data_path.split('/', 2)[2]
-        filename = urllib.parse.quote(filename.encode('utf-8'))
-        filepath = BASE_DIR + '/uploads/' + data_path
+        (filename, filepath) = download.csv_download_windows(problem.data.path, BASE_DIR, "problem") \
+            if os_info == 'Windows' else download.csv_download_nix(problem.data.path, BASE_DIR, "problem")
 
         # Open the file for reading content
         path = open(filepath, 'rb')
-
-        response = HttpResponse(FileWrapper(path), content_type='application/zip')
+        # Set the mime type
+        mime_type, _ = mimetypes.guess_type(filepath)
+        response = HttpResponse(path, content_type=mime_type)
         # Set the HTTP header for sending to browser
         response['Content-Disposition'] = 'attachment; filename*=UTF-8\'\'%s' % filename
+
         return response
 
 class ProblemSolutionDownloadView(APIView):
@@ -212,7 +211,6 @@ class ProblemSolutionDownloadView(APIView):
         os_info = platform.system()
 
         # Define Django project base directory
-
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         (filename, filepath) = download.csv_download_windows(problem.solution.path, BASE_DIR, "problem") \
             if os_info == 'Windows' else download.csv_download_nix(problem.solution.path, BASE_DIR, "problem")

--- a/problem/views/general.py
+++ b/problem/views/general.py
@@ -109,8 +109,8 @@ class ProblemDetailView(APIView):
     def get(self, request, problem_id):
         problem = get_problem(problem_id)
 
-        if problem.is_deleted is True:
-            return Response(status=status.HTTP_404_NOT_FOUND)
+        if problem is False:
+            return Response(msg_ProblemDetailView_delete_e_2, status=status.HTTP_204_NO_CONTENT)
 
         serializer = ProblemDetailSerializer(problem)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/problem/views/general.py
+++ b/problem/views/general.py
@@ -102,23 +102,17 @@ class ProblemView(APIView, PaginationHandlerMixin):
 
 class ProblemDetailView(APIView):
     permission_classes = [IsProblemOwnerOrReadOnly|IsAdmin]
-    if permission_classes is False:
-        raise NotFound(detail='Not Found.')
-
-    def get_object(self, id):
-        try:
-            return Problem.objects.get(pk=id)
-        except Problem.DoesNotExist:
-            return False
 
     # 03-04
     def get(self, request, problem_id):
-        problem = self.get_object(problem_id)
+        problem = get_problem(problem_id)
+
         if problem is False:
-            return Response(status=status.HTTP_404_NOT_FOUND)
-        serializer = ProblemDetailSerializer(problem)
+            raise NotFound(detail='Not Found.')
         if problem.is_deleted is True:
-            return Response(serializer.data, status=status.HTTP_204_NO_CONTENT)
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = ProblemDetailSerializer(problem)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     # 03-03

--- a/submission/views.py
+++ b/submission/views.py
@@ -329,8 +329,8 @@ class SubmissionClassCsvDownloadView(APIView):
         # Define Django project base directory
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-        (filename, filepath) = download.csv_download_windows(submission.csv.path, BASE_DIR) \
-            if os_info == 'Windows' else download.csv_download_nix(submission.csv.path, BASE_DIR)
+        (filename, filepath) = download.csv_download_windows(submission.csv.path, BASE_DIR, "submission") \
+            if os_info == 'Windows' else download.csv_download_nix(submission.csv.path, BASE_DIR, "submission")
 
         # Open the file for reading content
         path = open(filepath, 'r')
@@ -382,8 +382,8 @@ class SubmissionCompetitionCsvDownloadView(APIView):
         # Define Django project base directory
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-        (filename, filepath) = download.csv_download_windows(submission.csv.path, BASE_DIR) \
-            if os_info == 'Windows' else download.csv_download_nix(submission.csv.path, BASE_DIR)
+        (filename, filepath) = download.csv_download_windows(submission.csv.path, BASE_DIR, "submission") \
+            if os_info == 'Windows' else download.csv_download_nix(submission.csv.path, BASE_DIR, "submission")
 
         # Open the file for reading content
         path = open(filepath, 'r')

--- a/utils/download.py
+++ b/utils/download.py
@@ -12,8 +12,11 @@ from competition.models import Competition
 
 
 # For Windows
-def csv_download_windows(submission_path: str, base_dir: str or bytes) -> (str, str):
-    base_dir = base_dir.replace("\\submission", "")
+def csv_download_windows(submission_path: str, base_dir: str or bytes, type: str) -> (str, str, str):
+    if type == "submission":
+        base_dir = base_dir.replace("\\submission", "")
+    elif type == "problem":
+        base_dir = base_dir.replace("\\problem", "")
     csv_path = str(submission_path).split('uploads\\', 1)[1]
     filename = csv_path.split('\\', 2)[2]
     filename = urllib.parse.quote(filename.encode('utf-8'))
@@ -23,9 +26,12 @@ def csv_download_windows(submission_path: str, base_dir: str or bytes) -> (str, 
 
 
 # For Unix or Unix-compatible operating systems
-def csv_download_nix(submission_path: str, base_dir: str or bytes) -> (str, str):
+def csv_download_nix(submission_path: str, base_dir: str or bytes, type: str) -> (str, str, str):
     base_dir = base_dir.replace("/submission", "")
-
+    if type == "submission":
+        base_dir = base_dir.replace("/submission", "")
+    elif type == "problem":
+        base_dir = base_dir.replace("/problem", "")
     csv_path = str(submission_path).split('uploads/', 1)[1]
     filename = csv_path.split('/', 2)[2]
     filename = urllib.parse.quote(filename.encode('utf-8'))

--- a/utils/get_obj.py
+++ b/utils/get_obj.py
@@ -61,7 +61,7 @@ def get_competition(id):
 def get_problem(id):
     problem = get_object_or_404(Problem, id=id)
     if problem.is_deleted:
-        raise Http404()
+        return False
     return problem
 
 # contest

--- a/utils/message.py
+++ b/utils/message.py
@@ -35,9 +35,9 @@ msg_ExamParticipateView_get_e_2 = {"error": "해당 class에 속하지 않습니
 
 # problem
 msg_ProblemDetailView_delete_e_1 = {"success": "문제가 제거되었습니다."}
-msg_ProblemView_post_e_1 = {"error": "파일을 업로드 해주세요."}
-msg_ProblemView_post_e_2 = {"error": "올바른 데이터 파일을 업로드 해주세요."}
-msg_ProblemView_post_e_3 = {"error": "올바른 정답 파일을 업로드 해주세요."}
+msg_ProblemView_post_e_1 = {"code": 400, "message": "파일을 업로드 해주세요."}
+msg_ProblemView_post_e_2 = {"code": 400, "message": "올바른 데이터 파일을 업로드 해주세요."}
+msg_ProblemView_post_e_3 = {"code": 400, "message": "올바른 정답 파일을 업로드 해주세요."}
 
 
 # proposal

--- a/utils/message.py
+++ b/utils/message.py
@@ -35,10 +35,10 @@ msg_ExamParticipateView_get_e_2 = {"error": "해당 class에 속하지 않습니
 
 # problem
 msg_ProblemDetailView_delete_e_1 = {"success": "문제가 제거되었습니다."}
+msg_ProblemDetailView_delete_e_2 = {"code": 204, "message": "이미 삭제된 문제입니다."}
 msg_ProblemView_post_e_1 = {"code": 400, "message": "파일을 업로드 해주세요."}
 msg_ProblemView_post_e_2 = {"code": 400, "message": "올바른 데이터 파일을 업로드 해주세요."}
 msg_ProblemView_post_e_3 = {"code": 400, "message": "올바른 정답 파일을 업로드 해주세요."}
-
 
 # proposal
 


### PR DESCRIPTION
### 공통 수정사항
- API 명세서 index 주석 처리
- message.py의 error message "code", "message" 형태로 통일

### 추가 변동사항
- 기존 utils/download.py의 csv_download_windows, dsv_download_nix 에 인자 추가함 (string 인자) 
    - submission뿐만 아니라 problem에서도 해당 함수를 활용할 수 있도록 구분하는 인자 추가함
    - ProblemDataDownloadView, ProblemSolutionDownloadView에서 사용됨