### PR TITLE
BasicPagination 추가 구현 외

### DIFF
--- a/account/views/admin.py
+++ b/account/views/admin.py
@@ -5,14 +5,10 @@ from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework import status
 from rest_framework.pagination import PageNumberPagination
 from utils.get_obj import *
-from utils.pagination import PaginationHandlerMixin #pagination
+from utils.pagination import PaginationHandlerMixin, BasicPagination  # pagination
 from ..models import User
 from ..serializers import UserInfoSerializer, UserModifySerializer
 from utils.permission import IsAdmin
-
-
-class BasicPagination(PageNumberPagination):
-    page_size_query_param = 'limit'
 
 
 class ListUsersView(APIView, PaginationHandlerMixin):

--- a/announcement/views/admin.py
+++ b/announcement/views/admin.py
@@ -2,14 +2,13 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.pagination import PageNumberPagination #pagination
-from utils.pagination import PaginationHandlerMixin #pagination
+from rest_framework.pagination import PageNumberPagination  # pagination
+from utils.pagination import PaginationHandlerMixin, BasicPagination  # pagination
 from ..models import Announcement, User
 from ..serializers import AnnouncementSerializer, AnnouncementInfoSerializer, AnnouncementCheckSerializer
 from utils.get_obj import *
 from utils.permission import IsAdmin
-class BasicPagination(PageNumberPagination):
-    page_size_query_param = 'limit'
+
 
 class AnnouncementAdminView(APIView, PaginationHandlerMixin):
     permission_classes = [IsAdmin]

--- a/announcement/views/general.py
+++ b/announcement/views/general.py
@@ -2,15 +2,13 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status
 from django.http import Http404
-from rest_framework.pagination import PageNumberPagination #pagination
-from utils.pagination import PaginationHandlerMixin #pagination
+from rest_framework.pagination import PageNumberPagination  # pagination
+from utils.pagination import PaginationHandlerMixin, BasicPagination  # pagination
 from ..models import Announcement
 from ..serializers import AnnouncementSerializer, AnnouncementInfoSerializer
 from utils.get_obj import *
 from rest_framework.permissions import AllowAny
 
-class BasicPagination(PageNumberPagination):
-    page_size_query_param = 'limit'
 
 class AnnouncementView(APIView, PaginationHandlerMixin):
     # pagination

--- a/classes/views/admin.py
+++ b/classes/views/admin.py
@@ -56,4 +56,4 @@ class ClassAdminInfoView(APIView, PaginationHandlerMixin):
             list_paginator = ListPagination(request)
 
             return list_paginator.paginate_list(class_result_list, seggle.settings.REST_FRAMEWORK
-                                                .get('PAGE_SIZE', 15), request.GET.get('page', 1))
+                                                .get('PAGE_SIZE', 15), int(request.GET.get('page', 1)))

--- a/classes/views/admin.py
+++ b/classes/views/admin.py
@@ -40,7 +40,7 @@ class ClassAdminInfoView(APIView, PaginationHandlerMixin):
 
         else:
             class_result_list = []
-            created_user = get_object_or_404(ClassUser, username=uid)
+            created_user = ClassUser.objects.filter(username=uid).first()
             class_lists = Class.objects.filter(created_user=created_user.username).order_by('-id')
 
             for class_elem in class_lists:

--- a/contest/views.py
+++ b/contest/views.py
@@ -111,7 +111,7 @@ class ContestProblemView(APIView, PaginationHandlerMixin):
         p_size = seggle.settings.REST_FRAMEWORK.get('PAGE_SIZE', 15)
 
         return list_paginator.paginate_list(
-            contest_problem_list, p_size, request.GET.get('page', default=1))
+            contest_problem_list, p_size, int(request.GET.get('page', default=1)))
 
     # 05-13-01
     def post(self, request: Request, class_id: int, contest_id: int) -> Response:

--- a/exam/views.py
+++ b/exam/views.py
@@ -7,13 +7,10 @@ from rest_framework.response import Response
 from rest_framework import status
 from django.db.models import Q
 from rest_framework.pagination import PageNumberPagination
-from utils.pagination import PaginationHandlerMixin
+from utils.pagination import PaginationHandlerMixin, BasicPagination
 from utils.get_ip import GetIpAddr
 from contest.models import Contest
 from utils.permission import *
-
-class BasicPagination(PageNumberPagination):
-    page_size_query_param = 'limit'
 
 
 class ExamParticipateView(APIView, PaginationHandlerMixin):

--- a/leaderboard/views.py
+++ b/leaderboard/views.py
@@ -7,13 +7,10 @@ from rest_framework import status
 from utils.common import IP_ADDR
 from utils.permission import *
 from rest_framework.permissions import AllowAny
-from rest_framework.pagination import PageNumberPagination # pagination
-from utils.pagination import PaginationHandlerMixin # pagination
+from rest_framework.pagination import PageNumberPagination  # pagination
+from utils.pagination import PaginationHandlerMixin, BasicPagination  # pagination
 from rest_framework.status import HTTP_200_OK
 
-
-class BasicPagination(PageNumberPagination):
-    page_size_query_param = 'limit'
 
 class LeaderboardClassView(APIView, PaginationHandlerMixin):
     permission_classes = [IsCPUser]

--- a/problem/views/admin.py
+++ b/problem/views/admin.py
@@ -6,16 +6,13 @@ from ..serializers import AllProblemSerializer
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
-from utils.pagination import PaginationHandlerMixin
+from utils.pagination import PaginationHandlerMixin, BasicPagination
 from django.db.models import Q
 from rest_framework import status
 from utils.common import IP_ADDR
 import os
 import shutil
 from utils.permission import IsAdmin
-
-class BasicPagination(PageNumberPagination):
-    page_size_query_param = 'limit'
 
 
 class AdminProblemView(APIView, PaginationHandlerMixin):

--- a/problem/views/general.py
+++ b/problem/views/general.py
@@ -6,7 +6,7 @@ from ..serializers import ProblemSerializer, AllProblemSerializer, ProblemDetail
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
-from utils.pagination import PaginationHandlerMixin
+from utils.pagination import PaginationHandlerMixin, BasicPagination
 import utils.download as download
 from django.db.models import Q
 from django.http import HttpResponse
@@ -27,10 +27,6 @@ from utils.permission import *
 # permission import
 from rest_framework.permissions import AllowAny, IsAuthenticated, IsAdminUser
 from utils.permission import IsRightUser, IsProf, IsTA, IsProblemOwnerOrReadOnly, IsAdmin
-
-
-class BasicPagination(PageNumberPagination):
-    page_size_query_param = 'limit'
 
 
 class ProblemView(APIView, PaginationHandlerMixin):

--- a/proposal/views.py
+++ b/proposal/views.py
@@ -2,19 +2,17 @@ from multiprocessing import context
 from pickle import TRUE
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.permissions import IsAuthenticated,AllowAny,IsAuthenticatedOrReadOnly
+from rest_framework.permissions import IsAuthenticated, AllowAny, IsAuthenticatedOrReadOnly
 from rest_framework import status
 from .models import Proposal
-from rest_framework.pagination import PageNumberPagination #pagination
-from utils.pagination import PaginationHandlerMixin #pagination
+from rest_framework.pagination import PageNumberPagination  # pagination
+from utils.pagination import PaginationHandlerMixin, BasicPagination  # pagination
 from .serializers import ProposalSerializer, ProposalGetSerializer, ProposalPatchSerializer
 from utils.get_obj import *
 from utils.message import *
 from rest_framework.exceptions import ParseError, PermissionDenied
 # Create your views here.
 
-class BasicPagination(PageNumberPagination):
-    page_size_query_param = 'limit'
 
 class ProposalView(APIView, PaginationHandlerMixin):
     permission_classes = [IsAuthenticatedOrReadOnly]

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db.models import QuerySet
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
@@ -24,7 +26,7 @@ class PaginationHandlerMixin(object):
         if self.paginator is None:
             return None
         return self.paginator.paginate_queryset(queryset,
-                self.request, view=self)
+                                                self.request, view=self)
 
     def get_paginated_response(self, data):
         assert self.paginator is not None
@@ -34,8 +36,20 @@ class PaginationHandlerMixin(object):
 class BasicPagination(PageNumberPagination):
     page_size_query_param = 'limit'
 
+    def get_paginated_response(self, data):
+        response = OrderedDict([
+            ('count', len(data)),
+            #    ('next', self.get_next_link()),
+            #    ('previous', self.get_previous_link()),
+            ('current_page', self.page.number),
+            ('last_page', self.page.end_index()),
+            ('results', data),
+        ])
 
-# Pagination for list
+        return Response(response)
+
+
+# Pagination for list without serializer
 # https://stackoverflow.com/questions/38284440/drf-pagination-without-queryset
 class ListPagination:
     def __init__(self, request: Request):
@@ -58,8 +72,8 @@ class ListPagination:
                                                                page.next_page_number())
         response_dict = OrderedDict([
             ('count', len(data)),
-            ('next', next_url),
-            ('previous', previous_url),
+            #   ('next', next_url),
+            #   ('previous', previous_url),
             ('current_page', page_number),
             ('last_page', page.end_index()),
             ('results', page.object_list),

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -60,7 +60,9 @@ class ListPagination:
             ('count', len(data)),
             ('next', next_url),
             ('previous', previous_url),
-            ('results', page.object_list)
+            ('current_page', page_number),
+            ('last_page', page.end_index()),
+            ('results', page.object_list),
         ])
 
         return JsonResponse(response_dict, status=200, safe=False)


### PR DESCRIPTION
### 공통 수정사항
* API 명세서 index 주석 처리
* dictionary 접근 시 get 함수 이용

### 추가된 점
* BasicPagination에 current_page와 last_page 필드 추가 및 일부 필드 비활성화 (700ac48)
* ListPagination에 current_page와 last_page 필드 추가 및 일부 필드 비활성화 (a618a8f)

### 수정된 점
* 중복되는 BasicPagination 전부 삭제 (f733cc4)
* ClassAdminInfoView에서 사용자 정보를 잘못 가져오는 문제 수정 (bdb1d7c)
* ListPagination의 paginate_list() 메소드를 호출할 때 request.GET.get('page', 1)로 가져온 페이지 수가 문자열인 상태로 사용된 것 수정 (a618a8f)

가장 시급한 Pagination을 구현하였습니다.
