### PR TITLE
문제 생성, 편집, 삭제 방식 개량 외

### DIFF
--- a/classes/urls/general.py
+++ b/classes/urls/general.py
@@ -5,7 +5,7 @@ from classes.views.general import (
 
 )
 from contest.views import (
-    ContestView, ContestCheckView, ContestProblemView, ContestProblemOrderView, ContestProblemTitleDescptView,
+    ContestView, ContestCheckView, ContestProblemView, ContestProblemOrderView,
     ContestProblemInfoView,
 )
 
@@ -25,7 +25,6 @@ urlpatterns = [
     path('<int:class_id>/contests/', ContestView.as_view(), name="contest_api"),
     path('<int:class_id>/contests/<int:contest_id>/', ContestProblemView.as_view()),
     path('<int:class_id>/contests/<int:contest_id>/order/', ContestProblemOrderView.as_view()),
-    path('<int:class_id>/contests/<int:contest_id>/<int:cp_id>/description/', ContestProblemTitleDescptView.as_view()),
     path('<int:class_id>/contests/<int:contest_id>/check/', ContestCheckView.as_view()),
     path('<int:class_id>/contests/<int:contest_id>/<int:cp_id>/', ContestProblemInfoView.as_view()),
     path('<int:class_id>/contests/<int:contest_id>/<int:cp_id>/check/', SubmissionClassCheckView.as_view()),

--- a/competition/serializers.py
+++ b/competition/serializers.py
@@ -90,3 +90,10 @@ class CompetitionProblemInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = CompetitionProblem
         fields = ['id', 'order', 'problem_id', 'title', 'description', 'data', 'data_description', 'evaluation']
+
+
+class CompetitionProblemPutSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = CompetitionProblem
+        fields = '__all__'

--- a/competition/urls/general.py
+++ b/competition/urls/general.py
@@ -3,8 +3,7 @@ from competition.views.general import (
     CompetitionTaView,
     CompetitionUserView,
     CompetitionView,
-    CompetitionDetailView,
-    CompetitionProblemConfigurationView, CompetitionProblemOrderView, CompetitionCheckView, CompetitionProblemView
+    CompetitionDetailView, CompetitionProblemOrderView, CompetitionCheckView, CompetitionProblemView
 )
 from submission.views import SubmissionCompetitionView, SubmissionCompetitionListView, SubmissionCompetitionCheckView
 

--- a/competition/urls/general.py
+++ b/competition/urls/general.py
@@ -13,7 +13,6 @@ urlpatterns = [
     path('', CompetitionView.as_view(), name="competition"),
     path('<int:competition_id>/', CompetitionDetailView.as_view(), name="competition_detail"),
     path('<int:competition_id>/check/', CompetitionCheckView.as_view(), name="competition_check"),
-    path('<int:competition_id>/config/', CompetitionProblemConfigurationView.as_view(), name="manage_problems"),
     path('<int:competition_id>/order/', CompetitionProblemOrderView.as_view(), name="manage_problems"),
     path('<int:competition_id>/participation/', CompetitionUserView.as_view(), name='competition_user'),
     path('<int:competition_id>/participation/ta/', CompetitionTaView.as_view(), name='competition_ta'),

--- a/competition/views/general.py
+++ b/competition/views/general.py
@@ -159,9 +159,6 @@ class CompetitionDetailView(APIView, PaginationHandlerMixin):
 
         data = request.data.copy()
 
-        if data.get('problem_id', None) is not None:
-            pass
-
         if data.get('data', None) is None:
             return Response(msg_ProblemView_post_e_1, status=status.HTTP_400_BAD_REQUEST)
         if data.get('solution', None) is None:

--- a/contest/views.py
+++ b/contest/views.py
@@ -336,7 +336,7 @@ class ContestProblemInfoView(APIView):
 
             rt = {
                 'id': problem.id,
-                'con_p_id': conserializer.data.get('id'),
+                'cp_id': conserializer.data.get('id'),
                 'order': conserializer.data.get('order'),
                 'title': serializer.data.get('title'),
                 'description': serializer.data.get('description'),

--- a/contest/views.py
+++ b/contest/views.py
@@ -281,6 +281,9 @@ class ContestProblemInfoView(APIView):
         contest_problem = get_contest_problem(cp_id)
         problem = get_problem(id=contest_problem.problem_id.id)
 
+        if contest_problem.contest_id.id != contest_id or contest_problem.contest_id.class_id.id != class_id:
+            return Response(msg_error_invalid_url, status=status.HTTP_400_BAD_REQUEST)
+
         data = request.data
 
         if len(request.data) == 0:

--- a/utils/message.py
+++ b/utils/message.py
@@ -16,6 +16,7 @@ msg_error_no_selection = {"code": 400, "message": "대상을 선택해 주세요
 msg_error_url = {"code": 400, "message": "잘못된 URL 입니다."}
 msg_notfound = {"code": 404, "message": "콘텐츠를 찾을 수 없습니다."}
 msg_error_no_permission = {'code': 400, 'message': '권한이 없습니다.'}
+msg_error_no_request = {'code': 400, 'message': '바꿀 항목을 입력해 주세요.'}
 
 msg_success_check_public = {'code': 200, 'message': '성공적으로 공개로 바꾸었습니다.'}
 msg_success_check_private = {'code': 200, 'message': '성공적으로 비공개로 바꾸었습니다.'}


### PR DESCRIPTION
### 공통 수정사항
* API 명세서 index 주석 처리
* dictionary 접근 시 get 함수 이용

### 추가된 점


### 수정된 점
* problem을 competition이나 contest에서 직접 추가, 편집, 삭제 가능
* problem을 competition_problem이나 contest_problem에 일대일 대응으로 변경
* contest에서 description 관련 뷰 삭제
* competition에서 config 관련 뷰 삭제

### 문제점
* 리더보드가 새로운 Competition에 대응되지 않음
